### PR TITLE
JRuby Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /test/reports
 *.gem
 .tool-versions
+*.dll

--- a/.jrubyrc
+++ b/.jrubyrc
@@ -1,0 +1,1 @@
+debug.fullTrace=true

--- a/lib/mittsu/renderers/glfw_window.rb
+++ b/lib/mittsu/renderers/glfw_window.rb
@@ -4,6 +4,10 @@ require 'glfw'
 require 'mittsu/utils'
 require 'mittsu/renderers/glfw_lib'
 glfw_lib = Mittsu::GLFWLib.discover
+# Workaround until https://github.com/vaiorabbit/ruby-opengl/pull/32 gets merged
+GLFW.class_variable_get('@@lib_signature').each do |sig|
+  sig.gsub!(/const void(?!\s*\*)/, 'void')
+end
 GLFW.load_lib(ENV["MITTSU_LIBGLFW_FILE"] || glfw_lib.file, ENV["MITTSU_LIBGLFW_PATH"] || glfw_lib.path) unless Mittsu.test?
 
 include GLFW

--- a/lib/mittsu/renderers/glfw_window.rb
+++ b/lib/mittsu/renderers/glfw_window.rb
@@ -49,18 +49,18 @@ module Mittsu
             this.key_repeat_handler.call(key) unless this.key_repeat_handler.nil?
           end
         end
-        glfwSetKeyCallback(@handle, @key_callback)
+        glfwSetKeyCallback(@handle, Fiddle::Pointer[@key_callback.to_i])
 
         @char_callback = ::GLFW::create_callback(:GLFWcharfun) do |window_handle, codepoint|
           char = [codepoint].pack('U')
           this.char_input_handler.call(char) unless this.char_input_handler.nil?
         end
-        glfwSetCharCallback(@handle, @char_callback)
+        glfwSetCharCallback(@handle, Fiddle::Pointer[@char_callback.to_i])
 
         @cursor_pos_callback = ::GLFW::create_callback(:GLFWcursorposfun) do |window_handle, xpos, ypos|
           this.cursor_pos_handler.call(Vector2.new(xpos, ypos)) unless this.cursor_pos_handler.nil?
         end
-        glfwSetCursorPosCallback(@handle, @cursor_pos_callback)
+        glfwSetCursorPosCallback(@handle, Fiddle::Pointer[@cursor_pos_callback.to_i])
 
         @mouse_button_callback = ::GLFW::create_callback(:GLFWmousebuttonfun) do |window_handle, button, action, mods|
           mpos = this.mouse_position
@@ -70,17 +70,17 @@ module Mittsu
             this.mouse_button_release_handler.call(button, mpos) unless this.mouse_button_release_handler.nil?
           end
         end
-        glfwSetMouseButtonCallback(@handle, @mouse_button_callback)
+        glfwSetMouseButtonCallback(@handle, Fiddle::Pointer[@mouse_button_callback.to_i])
 
         @scroll_callback = ::GLFW::create_callback(:GLFWscrollfun) do |window_handle, xoffset, yoffset|
           this.scroll_handler.call(Vector2.new(xoffset, yoffset)) unless this.scroll_handler.nil?
         end
-        glfwSetScrollCallback(@handle, @scroll_callback)
+        glfwSetScrollCallback(@handle, Fiddle::Pointer[@scroll_callback.to_i])
 
         @frabuffer_size_callback = ::GLFW::create_callback(:GLFWframebuffersizefun) do |window_handle, new_width, new_height|
           this.framebuffer_size_handler.call(new_width, new_height) unless this.framebuffer_size_handler.nil?
         end
-        glfwSetFramebufferSizeCallback(@handle, @frabuffer_size_callback)
+        glfwSetFramebufferSizeCallback(@handle, Fiddle::Pointer[@frabuffer_size_callback.to_i])
 
         @joystick_buttons = poll_all_joysticks_buttons
       end

--- a/lib/mittsu/renderers/opengl/objects/mesh.rb
+++ b/lib/mittsu/renderers/opengl/objects/mesh.rb
@@ -10,12 +10,12 @@ module Mittsu
         @renderer.state.set_line_width(material.wireframe_linewidth * @renderer.pixel_ratio)
 
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, geometry_group.line_buffer) if update_buffers
-        glDrawElements(GL_LINES, geometry_group.line_count, type, 0)
+        glDrawElements(GL_LINES, geometry_group.line_count, type, nil)
 
       # triangles
       else
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, geometry_group.face_buffer) if update_buffers
-        glDrawElements(GL_TRIANGLES, geometry_group.face_count, type, 0)
+        glDrawElements(GL_TRIANGLES, geometry_group.face_count, type, nil)
       end
 
       @renderer.info[:render][:calls] += 1

--- a/lib/mittsu/renderers/opengl/opengl_geometry_like.rb
+++ b/lib/mittsu/renderers/opengl/opengl_geometry_like.rb
@@ -40,7 +40,7 @@ module Mittsu
     def update_vertex_buffer(attribute)
       glBindBuffer(GL_ARRAY_BUFFER, @vertex_buffer)
       @renderer.state.enable_attribute(attribute)
-      glVertexAttribPointer(attribute, 3, GL_FLOAT, GL_FALSE, 0, 0)
+      glVertexAttribPointer(attribute, 3, GL_FLOAT, GL_FALSE, 0, nil)
     end
 
     def update_other_buffers(object, material, attributes)
@@ -126,7 +126,7 @@ module Mittsu
     def update_attribute(attribute, buffer, size)
       glBindBuffer(GL_ARRAY_BUFFER, buffer)
       @renderer.state.enable_attribute(attribute)
-      glVertexAttribPointer(attribute, size, GL_FLOAT, GL_FALSE, 0, 0)
+      glVertexAttribPointer(attribute, size, GL_FLOAT, GL_FALSE, 0, nil)
     end
   end
 end

--- a/lib/mittsu/renderers/opengl/plugins/sprite_plugin.rb
+++ b/lib/mittsu/renderers/opengl/plugins/sprite_plugin.rb
@@ -131,8 +131,8 @@ module Mittsu
 
       glBindBuffer(GL_ARRAY_BUFFER, @vertex_buffer)
 
-      glVertexAttribPointer(@attributes[:position], 2, GL_FLOAT, GL_FALSE, 2 * 8, 0)
-      glVertexAttribPointer(@attributes[:uv], 2, GL_FLOAT, GL_FALSE, 2 * 8, 8)
+      glVertexAttribPointer(@attributes[:position], 2, GL_FLOAT, GL_FALSE, 2 * 8, Fiddle::Pointer[0])
+      glVertexAttribPointer(@attributes[:uv], 2, GL_FLOAT, GL_FALSE, 2 * 8, Fiddle::Pointer[8])
 
       glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, @element_buffer)
 

--- a/run_all_examples.ps1
+++ b/run_all_examples.ps1
@@ -1,0 +1,1 @@
+Get-ChildItem ".\examples\" -Filter *_example.rb | Foreach-Object { ruby $_.FullName }

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -4,4 +4,4 @@ set -e
 
 cd examples
 
-ls *.rb | grep '^[0-9]' | xargs -n 1 ruby
+ls *_example.rb | xargs -n 1 ruby


### PR DESCRIPTION
Work around some issues which prevented Mittsu from running on any version of JRuby.

1. Fiddle does not automatically convert function arguments to pointers unless they have a `to_ptr` method. `Fiddle::Closure` does not have a `to_ptr` method, and therefore cannot be passed as an argument (e.g. GLFW callbacks). Manually converting them to a pointer works around this issue.
2. Similarly, Ruby integers do not have a `to_ptr` method, And must therefore be manually converted to pointers before being passed as function arguments.
3. `nil`, however, is automatically converted to a nullptr in JRuby (and thus works as a suitable substitute for `0`)

TODO:

- [x]  Get blank scene example running in JRuby
- [x] Get geometry examples running in JRuby
- [ ] Some of the more complex examples (e.g. torus knot example) quit with no output
- [ ] The tests also quit with a non-zero exit code with no output (possibly same issue as above)
- [ ] Add JRuby to github action test matrix
- [ ] `print_tree` just prints question marks instead of the special drawing chars (could be an encoding issue? could be a windows-only issue?)