### PR TITLE
fix: GLFW.load_lib() on Windows OS

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -71,7 +71,7 @@ jobs:
     name: Windows
     runs-on: windows-latest
     env:
-      MITTSU_LIBGLFW_FILE: c:\projects\mittsu\glfw-3.3.1.bin.WIN32\lib-mingw\glfw3.dll
+      MITTSU_LIBGLFW_PATH: c:\projects\mittsu\glfw-3.3.1.bin.WIN32\lib-mingw
     strategy:
       matrix:
         ruby: ['2.5.x', '2.6.x', '2.7.x', '3.0.x']

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ sudo apt-get install libglfw3
 **NOTE:** On Windows, you will have to manually specify the glfw3.dll path in an environment variable
 (you can download it [here](http://www.glfw.org/download.html))
 ```bash
+# ex) set MITTSU_LIBGLFW_PATH=C:\Users\username\lib-mingw-w64
 > set MITTSU_LIBGLFW_PATH=C:\path\to\glfw3.dll
 > ruby your_awesome_mittsu_app.rb
 ```

--- a/lib/mittsu/renderers/glfw_lib.rb
+++ b/lib/mittsu/renderers/glfw_lib.rb
@@ -25,6 +25,9 @@ module Mittsu
     end
 
     class Windows < GenericLib::Base
+      def file
+        'glfw3.dll'
+      end
     end
 
     class MacOS < GenericLib::Base


### PR DESCRIPTION
I'm not a native English speaker, so I apologize for any strange English.

# Table of contents

* Summary
* About Error
* About Fix

## Summary

On Windows PC, I cannot load `glfw3.dll` because the argument of `GLFW.load_lib(file, path)` is wrong.

This pull request adds a method for the Windows platform so that `glfw3.dll` can be loaded.

## About Error

When I use mittsu on a windows PC, I get a type error in `opengl-bindings/glfw.rb`.

```ruby
# main.rb
require 'mittsu'
```

```powershell
# Powershell script to set env and run main.rb.
$ENV:MITTSU_LIBGLFW_PATH = "C:\Users\username\lib-mingw-w64"
# or $ENV:MITTSU_LIBGLFW_PATH = "C:\Users\username\lib-mingw-w64\glfw3.dll"
bundle exec ruby main.rb
```

```shell
# Error log
C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/opengl-bindings-1.6.11/lib/glfw.rb:505:in `+': no implicit conversion of nil into String (TypeError)
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/opengl-bindings-1.6.11/lib/glfw.rb:505:in `load_lib'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/mittsu-0.3.3/lib/mittsu/renderers/glfw_window.rb:8:in `<top (required)>'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/mittsu-0.3.3/lib/mittsu/renderers/opengl_renderer.rb:9:in `require'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/mittsu-0.3.3/lib/mittsu/renderers/opengl_renderer.rb:9:in `<top (required)>'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/mittsu-0.3.3/lib/mittsu/renderers.rb:1:in `require'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/mittsu-0.3.3/lib/mittsu/renderers.rb:1:in `<top (required)>'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/mittsu-0.3.3/lib/mittsu.rb:11:in `require'
        from C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/mittsu-0.3.3/lib/mittsu.rb:11:in `<top (required)>'
        from main.rb:1:in `require'
        from main.rb:1:in `<main>'
```

On Windows OS, this error occurs when calling `GLFW.load_lib(nil, ENV["MITTSU_LIBGLFW_PATH"])` because it is not the expected argument.

[mittsu  glfw_window.rb](https://github.com/danini-the-panini/mittsu/blob/bab1f357e5b3b42947e0da3987a6e87d7f6ec112/lib/mittsu/renderers/glfw_window.rb#L7)
```ruby
# glfw_window.rb in windows os
require 'opengl'
require 'glfw'

require 'mittsu/utils'
require 'mittsu/renderers/glfw_lib'
glfw_lib = Mittsu::GLFWLib.discover

GLFW.load_lib(ENV["MITTSU_LIBGLFW_FILE"] || glfw_lib.file, ENV["MITTSU_LIBGLFW_PATH"] || glfw_lib.path) unless Mittsu.test?
# => GLFW.load_lib(nil, "C:\\Users\\username\\lib-mingw-w64")
...
```

[opengl-bindings glfw.rb](https://github.com/vaiorabbit/ruby-opengl/blob/b19dde151a0bdb2efe8d062f768ef2fbca94b871/lib/glfw.rb#L491-L510)
```ruby
# opengl-bindings glfw.rb
# Called as GLFW.load_lib(nil, "C:\\Users\\username\\lib-mingw-w64")
...
def self.load_lib(lib = nil, path = nil, output_error = false)
  if lib == nil && path == nil
    case OpenGL.get_platform
    when :OPENGL_PLATFORM_WINDOWS
      lib, path = 'GLFW3.dll', Dir.pwd
    when :OPENGL_PLATFORM_MACOSX
      lib, path = 'libglfw.dylib', Dir.pwd
    else
      lib = 'libglfw.so'
    end
  end

  if path
    dlload (path + '/' + lib)
    # => dlload("C:\\Users\\username\\lib-mingw-w64" + '/' + nil)
    #                                                  ^^^^^^^^^
    # `+': no implicit conversion of nil into String (TypeError)
  else
    dlload (lib)
  end
  import_symbols(output_error) unless @@glfw_import_done
end
...
```

## About Fix

I believe this problem can be solved by defining a method for windows os in "glfw_lib.rb".

```diff
# mittsu/renderer/glfw_lib.rb
...
class Windows < GenericLib::Base
+ def file
+   'glfw3.dll'
+ end
end
...
```

### Expected Behavior

```ruby
# glfw_window.rb in windows os
require 'opengl'
require 'glfw'

require 'mittsu/utils'
require 'mittsu/renderers/glfw_lib'
glfw_lib = Mittsu::GLFWLib.discover

GLFW.load_lib(ENV["MITTSU_LIBGLFW_FILE"] || glfw_lib.file, ENV["MITTSU_LIBGLFW_PATH"] || glfw_lib.path) unless Mittsu.test?
# => GLFW.load_lib('glfw3.dll', "C:\\Users\\username\\lib-mingw-w64")
...
```

```ruby
# opengl-bindings glfw.rb
# Called as GLFW.load_lib('glfw3.dll', "C:\\Users\\username\\lib-mingw-w64")
...
def self.load_lib(lib = nil, path = nil, output_error = false)
  ...

  if path
    dlload (path + '/' + lib)
    # => dlload("C:\\Users\\username\\lib-mingw-w64" + '/' + 'glfw3.dll')
  else
    dlload (lib)
  end
  import_symbols(output_error) unless @@glfw_import_done
end
...
```