### PR TITLE
Fix "no implicit conversion of Array into String" errors

### DIFF
--- a/lib/mittsu/renderers/glfw_lib.rb
+++ b/lib/mittsu/renderers/glfw_lib.rb
@@ -36,11 +36,11 @@ module Mittsu
                       '/opt/homebrew/**']
 
       def path
-        File.dirname(match)
+        File.dirname(match.to_s)
       end
 
       def file
-        File.basename(match)
+        File.basename(match.to_s)
       end
 
       private


### PR DESCRIPTION
This occurs with the GLFW library paths being regex-matched on the MacOS platform variant in newer Ruby runtime versions.