### PR TITLE
JSON export bugfixes

### DIFF
--- a/lib/mittsu/core/geometry.rb
+++ b/lib/mittsu/core/geometry.rb
@@ -469,7 +469,7 @@ module Mittsu
       end
       vertices = []
       @vertices.each do |vert|
-        vertices << vertex.x << vertex.y << vertex.z
+        vertices << vert.x << vert.y << vert.z
       end
       faces = []
       normals = []
@@ -507,7 +507,7 @@ module Mittsu
           faces << get_uv_index(face_vertex_uvs[2], uvs_hash, uvs)
         end
         if has_face_normal
-          faces << get_normal_index(face.normal)
+          faces << get_normal_index(face.normal, normals_hash, normals)
         end
         if has_face_vertex_normal
           vertex_normals = face.vertex_normals

--- a/lib/mittsu/core/object_3d.rb
+++ b/lib/mittsu/core/object_3d.rb
@@ -357,7 +357,7 @@ module Mittsu
 
       if !self.children.empty?
         data[:children] = @children.map do |child|
-          child.jsonify
+          child.to_json
         end
       end
 

--- a/lib/mittsu/objects/line.rb
+++ b/lib/mittsu/objects/line.rb
@@ -143,9 +143,7 @@ module Mittsu
 
     def jsonify
       data = super
-      data[:geometry] = jsonify_geometry(self.geometry)
-      data[:material] = jsonify_material(self.material)
-      data[:mode] = self.mode
+      data[:object][:mode] = self.mode
       data
     end
   end

--- a/lib/mittsu/objects/mesh.rb
+++ b/lib/mittsu/objects/mesh.rb
@@ -269,10 +269,7 @@ module Mittsu
     protected
 
     def jsonify
-      data = super
-      data[:geometry] = jsonify_geometry(@geometry)
-      data[:material] = jsonify_material(@material)
-      data
+      super
     end
   end
 end

--- a/test/core/test_object_3d.rb
+++ b/test/core/test_object_3d.rb
@@ -151,6 +151,40 @@ class TestObject3D < Minitest::Test
     }, object.to_json)
   end
 
+  def test_to_json_with_mesh_child
+    object = Mittsu::Object3D.new
+    geometry = Mittsu::BoxGeometry.new(1.0, 1.0, 1.0)
+    material = Mittsu::MeshBasicMaterial.new(color: 0x00ff00)
+    object.add(Mittsu::Mesh.new(geometry, material))
+    # Check object basics
+    json = object.to_json
+    assert_equal('Mesh', json[:object][:children][0][:type])
+    # Check geometry node and uuid references
+    assert_equal('BoxGeometry', json[:geometries][0][:type])
+    assert_equal(json[:object][:children][0][:geometry],
+      json[:geometries][0][:uuid])
+    # Check material node and uuid references
+    assert_equal('MeshBasicMaterial', json[:materials][0][:type])
+    assert_equal(json[:object][:children][0][:material],
+      json[:materials][0][:uuid])
+  end
+
+  def test_to_json_with_line_child
+    object = Mittsu::Object3D.new
+    object.add(Mittsu::Line.new)
+    # Check object basics
+    json = object.to_json
+    assert_equal('Line', json[:object][:children][0][:type])
+    # Check geometry node and uuid references
+    assert_equal('Geometry', json[:geometries][0][:type])
+    assert_equal(json[:object][:children][0][:geometry],
+      json[:geometries][0][:uuid])
+    # Check material node and uuid references
+    assert_equal('LineBasicMaterial', json[:materials][0][:type])
+    assert_equal(json[:object][:children][0][:material],
+      json[:materials][0][:uuid])
+  end
+
   def test_clone
     object = Mittsu::Object3D.new
     object.name = 'Foo'


### PR DESCRIPTION
I was trying to debug my 3MF exporter using `to_json`, and found a few bugs that tripped it up. These changes fix those, so that running `to_json` on a loaded `male02.obj` file now works. No extra tests added, just a few quick tactical fixes that seem fairly obvious.

Incidentally, `to_json` in other contexts would normally produce a string, whereas this creates a hash which then needs `JSON.generate()` calling on it. Maybe something to reconsider down the line, what the "correct" output from `to_json` should be.