### PR TITLE
Fix Ruby 2 CI builds

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -16,12 +16,12 @@ jobs:
         ruby: ['2.6', '2.7', '3.0', '3.1', 'head']
     steps:
       - uses: actions/checkout@v4
+      - run: sudo apt-get update; sudo apt-get install cmake xorg-dev libgl1-mesa-dev
+      - run: bash install-glfw.sh
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: sudo apt-get update; sudo apt-get install cmake xorg-dev libgl1-mesa-dev
-      - run: bash install-glfw.sh
       - name: Test & publish code coverage
         uses: paambaati/codeclimate-action@v2.2.1
         if: github.event_name == 'push'
@@ -41,11 +41,11 @@ jobs:
         ruby: ['2.6', '2.7', '3.0', '3.1', 'head']
     steps:
       - uses: actions/checkout@v4
+      - run: brew install glfw
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: brew install glfw
       - run: bundle exec rake test
 
   windows:
@@ -58,9 +58,9 @@ jobs:
         ruby: ['2.6', '2.7', '3.0', '3.1', 'head']
     steps:
       - uses: actions/checkout@v4
+      - run: .\install-glfw.ps1
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: .\install-glfw.ps1
       - run: bundle exec rake test

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -22,7 +22,6 @@ jobs:
           bundler-cache: true
       - run: sudo apt-get update; sudo apt-get install cmake xorg-dev libgl1-mesa-dev
       - run: bash install-glfw.sh
-      - run: bundle install --path vendor/bundle
       - name: Test & publish code coverage
         uses: paambaati/codeclimate-action@v2.2.1
         if: github.event_name == 'push'
@@ -47,7 +46,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: brew install glfw
-      - run: bundle install --path vendor/bundle
       - run: bundle exec rake test
 
   windows:
@@ -65,6 +63,4 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: .\install-glfw.ps1
-      - run: gem install bundler
-      - run: bundle install --path vendor/bundle
       - run: bundle exec rake test

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         ruby: ['2.6', '2.7', '3.0', '3.1', 'head']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -40,7 +40,7 @@ jobs:
       matrix:
         ruby: ['2.6', '2.7', '3.0', '3.1', 'head']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -57,7 +57,7 @@ jobs:
       matrix:
         ruby: ['2.6', '2.7', '3.0', '3.1', 'head']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -16,8 +16,9 @@ jobs:
         ruby: ['2.6', '2.7', '3.0', '3.1', 'head']
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get update; sudo apt-get install cmake xorg-dev libgl1-mesa-dev
-      - run: bash install-glfw.sh
+      - uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libglfw3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -22,7 +22,6 @@ jobs:
           bundler-cache: true
       - run: sudo apt-get update; sudo apt-get install cmake xorg-dev libgl1-mesa-dev
       - run: bash install-glfw.sh
-      - run: gem install bundler
       - run: bundle install --path vendor/bundle
       - name: Test & publish code coverage
         uses: paambaati/codeclimate-action@v2.2.1


### PR DESCRIPTION
Setup-ruby installs bundler, so I think there's no need to do it manually. Trying to run these locally with `act` now, see if it helps.