### PR TITLE
Late naming for objects in OBJ loader

### DIFF
--- a/lib/mittsu/loaders/obj_loader.rb
+++ b/lib/mittsu/loaders/obj_loader.rb
@@ -53,7 +53,7 @@ module Mittsu
 
       when FACE_PATTERN         then parse_face(line)
 
-      when OBJECT_PATTERN       then new_object($1) and reset_vertices
+      when OBJECT_PATTERN       then handle_object($1)
       when GROUP_PATTERN        # ignore
       when SMOOTH_GROUP_PATTERN # ignore
 
@@ -105,9 +105,15 @@ module Mittsu
       raw_lines.split("\n").map(&:strip).reject(&:empty?).reject{|l| l.start_with? '#'}
     end
 
-    def new_object(object_name = '')
-      end_object
-      @object = Object3D.new
+    def handle_object(object_name = '')
+      # Reset if we're already working on a named object
+      # otherwise, just name the one we have in progress
+      unless @object&.name.nil?
+        end_object
+        reset_vertices
+        @object = nil
+      end
+      @object ||= Object3D.new
       @object.name = object_name
     end
 
@@ -120,7 +126,7 @@ module Mittsu
 
     def new_mesh
       end_mesh
-      new_object if @object.nil?
+      handle_object if @object.nil?
       @geometry = Geometry.new
       @mesh = Mesh.new(@geometry, @material || MeshLambertMaterial.new)
       @mesh.name = @object.name

--- a/test/loaders/test_obj_loader.rb
+++ b/test/loaders/test_obj_loader.rb
@@ -485,12 +485,12 @@ f 1/2/3 2/1/4 3/3/2 4/4/1
     loader = Mittsu::OBJLoader.new
 
     object = loader.parse """
-o square1
-
 v 0.0 1.0 0.0
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0
 v 1.0 1.0 0.0
+
+o square1
 
 f 1 2 4
 f 2 3 4


### PR DESCRIPTION
Handles late naming of first object in OBJ file. This happens in quite a few files found in the wild, where the first `o` declaration happens _after_ the vertex list.

Fixes a sub-issue identified in #123.