### PR TITLE
Suppress lspci and ldconfig errors unless in debug mode

### DIFF
--- a/lib/mittsu/renderers/generic_lib.rb
+++ b/lib/mittsu/renderers/generic_lib.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module Mittsu
   module GenericLib
     def discover
@@ -32,7 +34,8 @@ module Mittsu
 
       class << self
         def kernel_module_in_use
-          lspci_line = `lspci -nnk | grep -i vga -A3 | grep 'in use'`
+          lspci_line, stderr, _status = Open3.capture3("lspci -nnk | grep -i vga -A3 | grep 'in use'")
+          puts stderr if DEBUG
           /in use:\s*(\S+)/ =~ lspci_line && $1
         rescue
           ''

--- a/lib/mittsu/renderers/glfw_lib.rb
+++ b/lib/mittsu/renderers/glfw_lib.rb
@@ -17,7 +17,9 @@ module Mittsu
         end
 
         def ldconfig
-          `ldconfig -p | grep 'libglfw3\\?\\.so'`.lines
+          out, stderr, _status = Open3.capture3("ldconfig -p | grep 'libglfw3\\?\\.so'")
+          puts stderr if DEBUG
+          out.lines
         rescue
           []
         end


### PR DESCRIPTION
Resolves #127.

I think this works, though I need the CI to run on all platforms to make sure, and it could do with testing on a proper linux machine.