### PR TITLE
fix incorrect variable check in bounding sphere calc

### DIFF
--- a/lib/mittsu/core/buffer_geometry.rb
+++ b/lib/mittsu/core/buffer_geometry.rb
@@ -181,7 +181,7 @@ module Mittsu
 
         @bounding_sphere.radius = ::Math.sqrt(max_radius_sq)
 
-        if @bounding_radius.nan?
+        if @bounding_sphere.radius.nan?
           puts 'ERROR: Mittsu::BufferGeometry#computeBoundingSphere: Computed radius is NaN. The "position" attribute is likely to have NaN values.'
         end
       end


### PR DESCRIPTION
Just a quick fix for what I'm pretty sure is a typo in the ported bounding sphere method.